### PR TITLE
Fixed malfunction of the /sharebed command when the receiver already has beds

### DIFF
--- a/src/main/java/me/gabrielfj/multiplebedspawn/commands/ShareCommand.java
+++ b/src/main/java/me/gabrielfj/multiplebedspawn/commands/ShareCommand.java
@@ -72,7 +72,7 @@ public class ShareCommand extends BukkitCommand {
                         PlayerBedsData receiverBedsData;
                         PersistentDataContainer receiverData = receiverPlayer.getPersistentDataContainer();
                         if (receiverData.has(new NamespacedKey(plugin, "beds"), new BedsDataType())) {
-                            receiverBedsData = playerData.get(new NamespacedKey(plugin, "beds"), new BedsDataType());
+                            receiverBedsData = receiverData.get(new NamespacedKey(plugin, "beds"), new BedsDataType());
                             receiverBedsData.setNewBed(receiverPlayer, bed, bedUUID);
                         }else{
                             receiverBedsData = new PlayerBedsData(receiverPlayer, bed, bedUUID.toString());


### PR DESCRIPTION
There is a bug at the line [ShareCommand.java:75](https://github.com/GabrielFJunkes/MultipleBedSpawn/blob/6e4dbaf30891016c6f9e64cec6e7f5c41a9c9692/src/main/java/me/gabrielfj/multiplebedspawn/commands/ShareCommand.java#L75) which leads to malfunction of `/sharebed` command when the receiving player already has registered beds:

```java
receiverBedsData = playerData.get(new NamespacedKey(plugin, "beds"), new BedsDataType());
```

Here we're trying to get `PlayerBedsData` of the receiving player by invoking `get` on `playerData` which belongs to the owning player actually. Instead we should invoke `get` on `receiverData` which really belongs to the receiving player:

```java
receiverBedsData = receiverData.get(new NamespacedKey(plugin, "beds"), new BedsDataType());
```