### PR TITLE
Fixed /sharebed command completely

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.gabrielfj</groupId>
     <artifactId>MultipleBedSpawn</artifactId>
-    <version>1.9.1</version>
+    <version>1.9.2</version>
     <packaging>jar</packaging>
 
     <name>MultipleBedSpawn</name>

--- a/src/main/java/me/gabrielfj/multiplebedspawn/commands/ShareCommand.java
+++ b/src/main/java/me/gabrielfj/multiplebedspawn/commands/ShareCommand.java
@@ -1,7 +1,6 @@
 package me.gabrielfj.multiplebedspawn.commands;
 
 import static me.gabrielfj.multiplebedspawn.utils.BedsUtils.checkIfIsBed;
-import static me.gabrielfj.multiplebedspawn.utils.BedsUtils.removePlayerBed;
 
 import java.util.ArrayList;
 
@@ -69,18 +68,16 @@ public class ShareCommand extends BukkitCommand {
                 if (playerData.has(new NamespacedKey(plugin, "beds"), new BedsDataType())) {
                     playerBedsData = playerData.get(new NamespacedKey(plugin, "beds"), new BedsDataType());
                     if (playerBedsData!=null && playerBedsData.getPlayerBedData()!=null && playerBedsData.hasBed(bedUUID)){
-                        PlayerBedsData receiverBedsData;
                         PersistentDataContainer receiverData = receiverPlayer.getPersistentDataContainer();
-                        if (receiverData.has(new NamespacedKey(plugin, "beds"), new BedsDataType())) {
-                            receiverBedsData = receiverData.get(new NamespacedKey(plugin, "beds"), new BedsDataType());
-                            // We need to assign spawn location to the owning player location, not the receiving player location
-                            receiverBedsData.setNewBed(ownerPlayer, bed, bedUUID);
-                        }else{
-                            receiverBedsData = new PlayerBedsData(receiverPlayer, bed, bedUUID.toString());
-                        }
+                        PlayerBedsData receiverBedsData = receiverData.has(new NamespacedKey(plugin, "beds"), new BedsDataType())
+                            ? receiverData.get(new NamespacedKey(plugin, "beds"), new BedsDataType())
+                            : new PlayerBedsData();
+
+                        playerBedsData.shareBed(receiverBedsData, bedUUID);
                         receiverData.set(new NamespacedKey(plugin, "beds"), new BedsDataType(), receiverBedsData);
+                        playerData.set(new NamespacedKey(plugin, "beds"), new BedsDataType(), playerBedsData);
+
                         receiverPlayer.sendMessage(plugin.getMessages("bed-registered-successfully-message"));
-                        removePlayerBed(bedUUID, ownerPlayer, false);
                     }else{
                         ownerPlayer.sendMessage(ChatColor.RED + plugin.getMessages("bed-not-registered-message"));
                         return false;

--- a/src/main/java/me/gabrielfj/multiplebedspawn/commands/ShareCommand.java
+++ b/src/main/java/me/gabrielfj/multiplebedspawn/commands/ShareCommand.java
@@ -79,7 +79,7 @@ public class ShareCommand extends BukkitCommand {
                         }
                         receiverData.set(new NamespacedKey(plugin, "beds"), new BedsDataType(), receiverBedsData);
                         receiverPlayer.sendMessage(plugin.getMessages("bed-registered-successfully-message"));
-                        removePlayerBed(bedUUID, ownerPlayer);
+                        removePlayerBed(bedUUID, ownerPlayer, false);
                     }else{
                         ownerPlayer.sendMessage(ChatColor.RED + plugin.getMessages("bed-not-registered-message"));
                         return false;

--- a/src/main/java/me/gabrielfj/multiplebedspawn/commands/ShareCommand.java
+++ b/src/main/java/me/gabrielfj/multiplebedspawn/commands/ShareCommand.java
@@ -73,7 +73,8 @@ public class ShareCommand extends BukkitCommand {
                         PersistentDataContainer receiverData = receiverPlayer.getPersistentDataContainer();
                         if (receiverData.has(new NamespacedKey(plugin, "beds"), new BedsDataType())) {
                             receiverBedsData = receiverData.get(new NamespacedKey(plugin, "beds"), new BedsDataType());
-                            receiverBedsData.setNewBed(receiverPlayer, bed, bedUUID);
+                            // We need to assign spawn location to the owning player location, not the receiving player location
+                            receiverBedsData.setNewBed(ownerPlayer, bed, bedUUID);
                         }else{
                             receiverBedsData = new PlayerBedsData(receiverPlayer, bed, bedUUID.toString());
                         }

--- a/src/main/java/me/gabrielfj/multiplebedspawn/models/PlayerBedsData.java
+++ b/src/main/java/me/gabrielfj/multiplebedspawn/models/PlayerBedsData.java
@@ -7,8 +7,12 @@ import java.io.Serializable;
 import java.util.HashMap;
 
 public class PlayerBedsData implements Serializable {
+    private static final long serialVersionUID = 6158573570409965948L;
 
     private HashMap<String, BedData> bedData = new HashMap<String, BedData>();;
+
+    public PlayerBedsData() {
+    }
 
     public PlayerBedsData(Player p, Block bed, String bedUUID){
         BedData tempBedData = new BedData(bed, p);
@@ -18,6 +22,11 @@ public class PlayerBedsData implements Serializable {
     public void setNewBed(Player p, Block bed, String bedUUID){
         BedData tempBedData = new BedData(bed, p);
         this.bedData.put(bedUUID, tempBedData);
+    }
+
+    public void shareBed(PlayerBedsData receiverPlayerBedsData, String bedUUID) {
+        BedData bedToShare = bedData.remove(bedUUID);
+        receiverPlayerBedsData.bedData.put(bedUUID, bedToShare);
     }
 
     public void removeBed(String bedUUID){

--- a/src/main/java/me/gabrielfj/multiplebedspawn/utils/BedsUtils.java
+++ b/src/main/java/me/gabrielfj/multiplebedspawn/utils/BedsUtils.java
@@ -22,10 +22,6 @@ import java.util.HashMap;
 public class BedsUtils{
     static MultipleBedSpawn plugin = MultipleBedSpawn.getInstance();
     public static void removePlayerBed(String bedUUID, Player p){
-        removePlayerBed(bedUUID, p, true);
-    }
-
-    public static void removePlayerBed(String bedUUID, Player p, boolean removeBedUUID){
         PersistentDataContainer playerData = p.getPersistentDataContainer();
         // checks to see if player has beds
         if (playerData.has(new NamespacedKey(plugin, "beds"), new BedsDataType())) {
@@ -36,9 +32,23 @@ public class BedsUtils{
                 playerBedsData.removeBed(bedUUID);
                 playerData.set(new NamespacedKey(plugin, "beds"), new BedsDataType(), playerBedsData);
 
-                if (removeBedUUID) {
-                    removeBedUUID(bedData);
+                World world = Bukkit.getWorld(bedData.getBedWorld());
+                String loc[] = bedData.getBedCoords().split(":");
+                Location locBed = new Location(world, Double.parseDouble(loc[0]), Double.parseDouble(loc[1]),Double.parseDouble(loc[2]));
+                Block bed = world.getBlockAt(locBed);
+                if (bed.getBlockData() instanceof Bed bedPart){
+                    // since the data is in the head we need to set the Block bed to its head
+                    if (bedPart.getPart().toString()=="FOOT"){
+                        bed = (Block) bed.getRelative(bedPart.getFacing());
+                    }
                 }
+                BlockState blockState = bed.getState();
+                if (blockState instanceof TileState tileState){
+                    PersistentDataContainer container = tileState.getPersistentDataContainer();
+                    container.remove(new NamespacedKey(plugin, "uuid"));
+                    tileState.update();
+                }
+
             }
         }
     }
@@ -122,24 +132,5 @@ public class BedsUtils{
             maxBeds = maxBedsByPerms;
         }
         return maxBeds;
-    }
-
-    private static void removeBedUUID(BedData bedData) {
-        World world = Bukkit.getWorld(bedData.getBedWorld());
-        String loc[] = bedData.getBedCoords().split(":");
-        Location locBed = new Location(world, Double.parseDouble(loc[0]), Double.parseDouble(loc[1]),Double.parseDouble(loc[2]));
-        Block bed = world.getBlockAt(locBed);
-        if (bed.getBlockData() instanceof Bed bedPart){
-            // since the data is in the head we need to set the Block bed to its head
-            if (bedPart.getPart().toString()=="FOOT"){
-                bed = (Block) bed.getRelative(bedPart.getFacing());
-            }
-        }
-        BlockState blockState = bed.getState();
-        if (blockState instanceof TileState tileState){
-            PersistentDataContainer container = tileState.getPersistentDataContainer();
-            container.remove(new NamespacedKey(plugin, "uuid"));
-            tileState.update();
-        }
     }
 }

--- a/src/main/java/me/gabrielfj/multiplebedspawn/utils/BedsUtils.java
+++ b/src/main/java/me/gabrielfj/multiplebedspawn/utils/BedsUtils.java
@@ -22,6 +22,10 @@ import java.util.HashMap;
 public class BedsUtils{
     static MultipleBedSpawn plugin = MultipleBedSpawn.getInstance();
     public static void removePlayerBed(String bedUUID, Player p){
+        removePlayerBed(bedUUID, p, true);
+    }
+
+    public static void removePlayerBed(String bedUUID, Player p, boolean removeBedUUID){
         PersistentDataContainer playerData = p.getPersistentDataContainer();
         // checks to see if player has beds
         if (playerData.has(new NamespacedKey(plugin, "beds"), new BedsDataType())) {
@@ -32,23 +36,9 @@ public class BedsUtils{
                 playerBedsData.removeBed(bedUUID);
                 playerData.set(new NamespacedKey(plugin, "beds"), new BedsDataType(), playerBedsData);
 
-                World world = Bukkit.getWorld(bedData.getBedWorld());
-                String loc[] = bedData.getBedCoords().split(":");
-                Location locBed = new Location(world, Double.parseDouble(loc[0]), Double.parseDouble(loc[1]),Double.parseDouble(loc[2]));
-                Block bed = world.getBlockAt(locBed);
-                if (bed.getBlockData() instanceof Bed bedPart){
-                    // since the data is in the head we need to set the Block bed to its head
-                    if (bedPart.getPart().toString()=="FOOT"){
-                        bed = (Block) bed.getRelative(bedPart.getFacing());
-                    }
+                if (removeBedUUID) {
+                    removeBedUUID(bedData);
                 }
-                BlockState blockState = bed.getState();
-                if (blockState instanceof TileState tileState){
-                    PersistentDataContainer container = tileState.getPersistentDataContainer();
-                    container.remove(new NamespacedKey(plugin, "uuid"));
-                    tileState.update();
-                }
-
             }
         }
     }
@@ -132,5 +122,24 @@ public class BedsUtils{
             maxBeds = maxBedsByPerms;
         }
         return maxBeds;
+    }
+
+    private static void removeBedUUID(BedData bedData) {
+        World world = Bukkit.getWorld(bedData.getBedWorld());
+        String loc[] = bedData.getBedCoords().split(":");
+        Location locBed = new Location(world, Double.parseDouble(loc[0]), Double.parseDouble(loc[1]),Double.parseDouble(loc[2]));
+        Block bed = world.getBlockAt(locBed);
+        if (bed.getBlockData() instanceof Bed bedPart){
+            // since the data is in the head we need to set the Block bed to its head
+            if (bedPart.getPart().toString()=="FOOT"){
+                bed = (Block) bed.getRelative(bedPart.getFacing());
+            }
+        }
+        BlockState blockState = bed.getState();
+        if (blockState instanceof TileState tileState){
+            PersistentDataContainer container = tileState.getPersistentDataContainer();
+            container.remove(new NamespacedKey(plugin, "uuid"));
+            tileState.update();
+        }
     }
 }


### PR DESCRIPTION
Finally made `/sharebed` command to work properly (I thought #27 did, but testing showed it didn't). This pull request includes the following changes:

- Fixed errorenous removal of bed UUID on bed sharing which led to inability of the receiving player to use the shared bed
- Fixed wrong teleport on shared bed
- Keep bed name and spawn location when it gets shared

This time I tested the changes and I believe that I did that properly. At least works for me 🙂